### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: installer-test
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/qbee-io/qbee-agent-installers/security/code-scanning/1](https://github.com/qbee-io/qbee-agent-installers/security/code-scanning/1)

To fix the issue, explicitly specify a minimal `permissions` policy for the workflow, restricting the GITHUB_TOKEN to the minimum access needed (usually `contents: read` for installation/test jobs). This can be set at the workflow root (to apply to all jobs), or at the job level. For this workflow, adding it at the root makes the most sense for future extensibility and clarity. To do so, add the following lines after the `name` block and before the `on` block:

```yaml
permissions:
  contents: read
```

No other modifications to the jobs or steps are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
