### PR TITLE
Test on legacy raspbian

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -46,6 +46,12 @@ jobs:
           docker exec centos7 bash qbee-agent-installer.sh
 
           docker kill centos7
+          
+      - name: Test install legacy raspbian
+        run: |
+          docker run -d --name raspbian8 --rm -v $(pwd):/app:ro -w /app hypriot/rpi-raspbian:jessie sleep 60
+          docker exec raspbian8 bash qbee-agent-installer.sh
+          docker kill raspbian8
 
   test-arm64:
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Test install legacy raspbian (armhf)
         run: |
+          docker run --privileged --rm tonistiigi/binfmt --install all
           docker run -d --name raspbian8 --rm -v $(pwd):/app:ro -w /app raspbian/jessie:041518 sleep 60
           docker exec raspbian8 bash qbee-agent-installer.sh
           docker kill raspbian8

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -47,13 +47,6 @@ jobs:
 
           docker kill centos7
 
-      - name: Test install legacy raspbian (armhf)
-        run: |
-          docker run --privileged --rm tonistiigi/binfmt --install all
-          docker run -d --name raspbian8 --rm -v $(pwd):/app:ro -w /app raspbian/jessie:041518 sleep 60
-          docker exec raspbian8 bash qbee-agent-installer.sh
-          docker kill raspbian8
-
   test-arm64:
     runs-on: ubuntu-24.04-arm
 
@@ -93,3 +86,12 @@ jobs:
 
           docker kill centos7
 
+  test-armhf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test install legacy raspbian (armhf)
+        run: |
+          docker run --privileged --rm tonistiigi/binfmt --install all
+          docker run -d --name raspbian8 --rm -v $(pwd):/app:ro -w /app raspbian/jessie:041518 sleep 60
+          docker exec raspbian8 bash qbee-agent-installer.sh
+          docker kill raspbian8

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -46,10 +46,10 @@ jobs:
           docker exec centos7 bash qbee-agent-installer.sh
 
           docker kill centos7
-          
-      - name: Test install legacy raspbian
+
+      - name: Test install legacy raspbian (armhf)
         run: |
-          docker run -d --name raspbian8 --rm -v $(pwd):/app:ro -w /app hypriot/rpi-raspbian:jessie sleep 60
+          docker run -d --name raspbian8 --rm -v $(pwd):/app:ro -w /app raspbian/jessie:041518 sleep 60
           docker exec raspbian8 bash qbee-agent-installer.sh
           docker kill raspbian8
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -91,8 +91,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - name: Test install legacy raspbian (armhf)
+      - name: Test install legacy raspbian
         run: |
+          docker run --privileged --rm tonistiigi/binfmt --install all
           docker run --platform linux/arm/v7 -d --name raspbian8 --rm -v $(pwd):/app:ro -w /app raspbian/jessie:041518 sleep 60
           docker exec raspbian8 bash qbee-agent-installer.sh
           docker kill raspbian8

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -93,7 +93,6 @@ jobs:
       
       - name: Test install legacy raspbian (armhf)
         run: |
-          docker run --privileged --rm tonistiigi/binfmt --install all
-          docker run -d --name raspbian8 --rm -v $(pwd):/app:ro -w /app raspbian/jessie:041518 sleep 60
+          docker run --platform linux/arm/v7 -d --name raspbian8 --rm -v $(pwd):/app:ro -w /app raspbian/jessie:041518 sleep 60
           docker exec raspbian8 bash qbee-agent-installer.sh
           docker kill raspbian8

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -89,6 +89,8 @@ jobs:
   test-armhf:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      
       - name: Test install legacy raspbian (armhf)
         run: |
           docker run --privileged --rm tonistiigi/binfmt --install all


### PR DESCRIPTION
This pull request adds a new job to the GitHub Actions workflow to test installation on legacy Raspbian (ARMv7) environments. This ensures better compatibility and coverage for ARM-based platforms.

**CI/CD enhancements:**

* Added a `test-armhf` job to `.github/workflows/pr-test.yml` that runs installation tests on a legacy Raspbian Jessie (ARMv7) Docker container using `qbee-agent-installer.sh`.