### PR TITLE
DEV-2718: Check for non terminal

### DIFF
--- a/qbee-agent-upgrade/qbee-agent-upgrade.sh
+++ b/qbee-agent-upgrade/qbee-agent-upgrade.sh
@@ -45,23 +45,6 @@ check_system_utilities() {
   fi
 }
 
-check_agent_sanity() {
-  if [[ ! -f /etc/qbee/qbee-agent.json ]]; then
-    echo "ERROR: qbee-agent configuration file not found"
-    exit 1
-  fi
-
-  if [[ ! -f /etc/qbee/ppkeys/qbee.cert ]]; then
-    echo "ERROR: qbee-agent certificate not found"
-    exit 1
-  fi
-
-  if [[ ! -f /etc/qbee/ppkeys/qbee.key ]]; then
-    echo "ERROR: qbee-agent key not found"
-    exit 1
-  fi
-}
-
 check_package_name() {
   local pkg_name
   pkg_name="$1"

--- a/qbee-agent-upgrade/qbee-agent-upgrade.sh
+++ b/qbee-agent-upgrade/qbee-agent-upgrade.sh
@@ -92,6 +92,8 @@ check_package_version() {
 check_dpkg_lock() {
   # disable pipefail for this particular test, or it will not work properly
   set +o pipefail
+
+  # shellcheck disable=SC2010
   if ls -lt /proc/[0-9]*/fd 2> /dev/null | grep -q /var/lib/dpkg/lock; then
     echo "ERROR: Package manager is already running, unable to upgrade" 
     exit 1

--- a/qbee-agent-upgrade/qbee-agent-upgrade.sh
+++ b/qbee-agent-upgrade/qbee-agent-upgrade.sh
@@ -31,6 +31,13 @@ if [[ ! -f "$1" ]]; then
   exit 1
 fi
 
+check_shell_not_terminal() {
+  if [[ -t 0 ]]; then
+    echo "ERROR: this script must not be run in a terminal, please read the documentation"
+    exit 1
+  fi
+}
+
 check_system_utilities() {
   if [[ ! -x "$(command -v mktemp)" ]]; then
     echo "ERROR: mktemp is required to run this script"
@@ -163,6 +170,7 @@ sanity_rpm() {
 dpkg_path=$(command -v dpkg || true)
 rpm_path=$(command -v rpm || true)
 
+check_shell_not_terminal
 check_system_utilities
 
 if [[ -n "${dpkg_path}" ]]; then


### PR DESCRIPTION
This pull request refactors the `qbee-agent-upgrade.sh` script to improve its safety and reliability by introducing a check that prevents running the script directly in a terminal, and by reorganizing some of the sanity and utility checks. The most important changes are grouped below.

**Safety improvements:**

* Added a new `check_shell_not_terminal` function to ensure the script is not executed from an interactive terminal, which helps prevent accidental misuse. This check is now called at the start of the upgrade process. [[1]](diffhunk://#diff-bc08951f9930f21750740e3a106705358c3638b0700a59229b33e7c81aa77292L34-R43) [[2]](diffhunk://#diff-bc08951f9930f21750740e3a106705358c3638b0700a59229b33e7c81aa77292R158)

**Sanity and utility checks:**

* Reorganized the sanity and utility check functions: removed the previous `check_agent_sanity` function and adjusted the order and implementation of `check_system_utilities` for clarity.

**Package manager reliability:**

* Added a comment and shellcheck directive to clarify the use of `ls` and suppress warnings in the `check_dpkg_lock` function, improving maintainability.