### PR TITLE
Simplify fetching of the latest release tag in the installer script

### DIFF
--- a/manifest-cf.yaml
+++ b/manifest-cf.yaml
@@ -37,7 +37,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:PutObject
-                Resource: !Sub 'arn:aws:s3:::${ExistingBucketName}/*'
+                Resource: !Sub 'arn:aws:s3:::${ExistingBucketName}/latest.txt'
 
   UpdateManifestLambda:
     Type: AWS::Lambda::Function
@@ -69,7 +69,7 @@ Resources:
               if token:
                   req.add_header('Authorization', f'Bearer {token}')
 
-              with urllib.request.urlopen(req) as response:
+              with urllib.request.urlopen(req, timeout=10) as response:
                   payload = json.loads(response.read().decode('utf-8'))
 
               tag_name = payload.get('tag_name', '')

--- a/manifest-cf.yaml
+++ b/manifest-cf.yaml
@@ -1,0 +1,119 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: S3 Static Manifest generator using an existing S3 bucket
+
+Parameters:
+  ExistingBucketName:
+    Type: String
+    Description: Name of your existing S3 bucket (must allow public reads if accessed directly).
+  GitHubRepo:
+    Type: String
+    Default: 'qbee-io/qbee-agent'
+    Description: Target GitHub repository (owner/repo format).
+  GitHubToken:
+    Type: String
+    NoEcho: true
+    Default: ''
+    Description: (Optional) Personal Access Token to increase GitHub API limits for Lambda.
+
+Resources:
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: S3WriteManifestPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource: !Sub 'arn:aws:s3:::${ExistingBucketName}/*'
+
+  UpdateManifestLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: python3.12
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Timeout: 30
+      Environment:
+        Variables:
+          S3_BUCKET_NAME: !Ref ExistingBucketName
+          GITHUB_REPO: !Ref GitHubRepo
+          GITHUB_TOKEN: !Ref GitHubToken
+      Code:
+        ZipFile: |
+          import json
+          import os
+          import urllib.request
+          import boto3
+
+          def handler(event, context):
+              bucket = os.environ['S3_BUCKET_NAME']
+              repo = os.environ['GITHUB_REPO']
+              token = os.environ.get('GITHUB_TOKEN')
+
+              url = f"https://api.github.com/repos/{repo}/releases/latest"
+              req = urllib.request.Request(url, headers={'User-Agent': 'AWS-Lambda-Manifest'})
+              
+              if token:
+                  req.add_header('Authorization', f'Bearer {token}')
+
+              with urllib.request.urlopen(req) as response:
+                  payload = json.loads(response.read().decode('utf-8'))
+
+              tag_name = payload.get('tag_name', '')
+
+              if not tag_name:
+                  raise ValueError("No tag_name found in the latest release payload")
+              
+              s3 = boto3.client('s3')
+              
+              # Write plain-text version string
+              s3.put_object(
+                  Bucket=bucket,
+                  Key='latest.txt',
+                  Body=tag_name,
+                  ContentType='text/plain'
+              )
+              
+              return {"statusCode": 200, "body": f"Updated version to {tag_name}"}
+
+  SchedulerExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: scheduler.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: InvokeLambdaPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !GetAtt UpdateManifestLambda.Arn
+
+  Scheduler:
+    Type: AWS::Scheduler::Schedule
+    Properties:
+      ScheduleExpression: "rate(5 minutes)"
+      FlexibleTimeWindow:
+        Mode: "OFF"
+      Target:
+        Arn: !GetAtt UpdateManifestLambda.Arn
+        RoleArn: !GetAtt SchedulerExecutionRole.Arn

--- a/qbee-agent-installer.sh
+++ b/qbee-agent-installer.sh
@@ -20,7 +20,7 @@
 set -eu
 
 REPO="qbee-io/qbee-agent"
-API="https://api.github.com/repos/$REPO/releases/latest"
+LATEST_TAG_URL="https://setup.qbee.io/latest.txt"
 WORKDIR="${TMPDIR:-/tmp}/qbee-agent-install.$$"
 
 die() { echo "Error: $*" >&2; exit 1; }
@@ -85,7 +85,7 @@ done
 # --- Determine package version ---
 if [[ -z $QBEE_AGENT_VERSION ]]; then
   info "No package version provided, using latest release."
-  TAG=$($GET "$API" | grep '"tag_name":' | cut -d '"' -f 4) || die "Failed to query latest release"
+  TAG="$($GET "$LATEST_TAG_URL")" || die "Failed to query latest release"
 else
   # --- Remove trailing .0 if present ---
   TAG="${QBEE_AGENT_VERSION%.0}"

--- a/qbee-agent-installer.sh
+++ b/qbee-agent-installer.sh
@@ -85,11 +85,13 @@ done
 # --- Determine package version ---
 if [[ -z $QBEE_AGENT_VERSION ]]; then
   info "No package version provided, using latest release."
-  TAG="$($GET "$LATEST_TAG_URL")" || die "Failed to query latest release"
+  TAG="$($GET "$LATEST_TAG_URL" | tr -d '[:space:]')" || die "Failed to query latest release"
 else
   # --- Remove trailing .0 if present ---
   TAG="${QBEE_AGENT_VERSION%.0}"
 fi
+
+[[ -n "$TAG" ]] || die "Failed to determine package version"
 
 # --- extract major version ---
 MAJOR_VERSION="${TAG%%.*}"


### PR DESCRIPTION
This pull request introduces an AWS CloudFormation template (`manifest-cf.yaml`) to automate the generation of a static manifest for the latest release of the `qbee-agent` project and updates the installer script (`qbee-agent-installer.sh`) to use this manifest for determining the latest version. The changes decouple the installer from direct GitHub API calls, improving reliability and reducing dependency on GitHub API rate limits.

**Infrastructure automation:**
* Added `manifest-cf.yaml`, a CloudFormation template that provisions an AWS Lambda function and EventBridge Scheduler to periodically fetch the latest release tag from a specified GitHub repository and write it to an S3 bucket as `latest.txt`. This allows clients to retrieve the latest version without querying the GitHub API directly.

**Installer script update:**
* Modified `qbee-agent-installer.sh` to use the new static URL (`https://setup.qbee.io/latest.txt`) for fetching the latest release tag instead of querying the GitHub API, reducing API usage and improving script robustness. [[1]](diffhunk://#diff-1cc80649199106c1cf82181033ddf068ce952606351ccdbd6acad4471bf1a3f4L23-R23) [[2]](diffhunk://#diff-1cc80649199106c1cf82181033ddf068ce952606351ccdbd6acad4471bf1a3f4L88-R88)