### PR TITLE
Switch to mktemp for creation of secure temp directory.

### DIFF
--- a/qbee-agent-installer.sh
+++ b/qbee-agent-installer.sh
@@ -19,13 +19,15 @@
 # --- Setup environment ---
 set -eu
 
+umask 077
+
 REPO="qbee-io/qbee-agent"
 API="https://api.github.com/repos/$REPO/releases/latest"
-WORKDIR="${TMPDIR:-/tmp}/qbee-agent-install.$$"
 
 die() { echo "Error: $*" >&2; exit 1; }
 info(){ echo "==> $*"; }
-cleanup(){ [ -d "$WORKDIR" ] && rm -rf "$WORKDIR"; }
+WORKDIR=$(mktemp -d) || die "Cannot create secure temp dir"
+cleanup(){ [ -d "$WORKDIR" ] && rm -rf -- "$WORKDIR"; }
 trap cleanup EXIT INT TERM
 
 # --- Check whether we have wget or curl ---
@@ -43,7 +45,6 @@ if [[ $(whoami) != "root" ]]; then
 fi
 
 # --- Switch to workdir ---
-mkdir -p "$WORKDIR" || die "Cannot create temp dir"
 info "Switching to workdir: $WORKDIR"
 cd "$WORKDIR"
 

--- a/qbee-agent-installer.sh
+++ b/qbee-agent-installer.sh
@@ -26,7 +26,7 @@ API="https://api.github.com/repos/$REPO/releases/latest"
 
 die() { echo "Error: $*" >&2; exit 1; }
 info(){ echo "==> $*"; }
-WORKDIR=$(mktemp -d) || die "Cannot create secure temp dir"
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/qbee-agent-install.XXXXXX") || die "Cannot create secure temp dir"
 cleanup(){ [ -d "$WORKDIR" ] && rm -rf -- "$WORKDIR"; }
 trap cleanup EXIT INT TERM
 


### PR DESCRIPTION
This pull request makes security and reliability improvements to the `qbee-agent-installer.sh` script by enhancing how temporary files are handled and ensuring stricter file permissions. The most important changes are:

Security improvements:
* Set a restrictive file creation mask (`umask 077`) at the start of the script to ensure that any files created are only accessible by the current user, reducing the risk of leaking sensitive information.

Temporary directory handling:
* Use `mktemp -d` to securely create a unique temporary working directory for the installer, replacing the previous approach that used a predictable path. This helps prevent potential race conditions and security issues.
* Remove the redundant `mkdir -p "$WORKDIR"` command, since `mktemp -d` already creates the directory.
* Ensure the `cleanup` function deletes the temporary directory securely by using `rm -rf -- "$WORKDIR"` and checking the directory exists.