### PR TITLE
Add Lambda monitoring and alerting

### DIFF
--- a/manifest-cf.yaml
+++ b/manifest-cf.yaml
@@ -15,6 +15,9 @@ Parameters:
     NoEcho: true
     Default: ''
     Description: (Optional) Personal Access Token to increase GitHub API limits for Lambda.
+  AlarmSnsTopicArn:
+    Type: String
+    Description: SNS topic ARN for Lambda error alarm notifications.
 
 Resources:
   LambdaExecutionRole:
@@ -117,3 +120,21 @@ Resources:
       Target:
         Arn: !GetAtt UpdateManifestLambda.Arn
         RoleArn: !GetAtt SchedulerExecutionRole.Arn
+
+  LambdaErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: lambda-errors-setup-qbee-io
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      AlarmDescription: Triggers when Lambda errors exceed threshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref UpdateManifestLambda
+      AlarmActions:
+        - !Ref AlarmSnsTopicArn


### PR DESCRIPTION
This pull request adds monitoring and alerting for Lambda function errors in the CloudFormation template. The main changes introduce a new CloudWatch alarm resource and a parameter for specifying an SNS topic to receive notifications.

**Monitoring and alerting enhancements:**

* Added a new `AlarmSnsTopicArn` parameter to the `manifest-cf.yaml` template to allow configuration of an SNS topic ARN for Lambda error alarm notifications.
* Introduced a `LambdaErrorsAlarm` CloudWatch alarm resource that monitors the `UpdateManifestLambda` function for errors and sends notifications to the specified SNS topic when errors exceed the threshold.